### PR TITLE
update zenodo json for lesson release

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -2,57 +2,35 @@
   "contributors": [
     {
       "type": "Editor",
-      "name": "Christopher Prener",
-      "orcid": "0000-0002-4310-9888"
+      "name": "Tyson Lee Swetnam",
+      "orcid": "0000-0002-6639-7181"
     },
     {
       "type": "Editor",
-      "name": "Tyson Lee Swetnam",
-      "orcid": "0000-0002-6639-7181"
+      "name": "Rohit Goswami",
+      "orcid": "0000-0002-2393-8056"
+    },
+    {
+      "type": "Editor",
+      "name": "Aditya Ranganath"
+    },
+    {
+      "type": "Editor",
+      "name": "Girmaye Misgna"
+    },
+    {
+      "type": "Editor",
+      "name": "Marissa Block"
     }
   ],
   "creators": [
-    {
-      "name": "Lauren O'Brien",
-      "orcid": "0000-0002-7336-2171"
-    },
     {
       "name": "Jemma Stachelek",
       "orcid": "0000-0002-5924-2464"
     },
     {
-      "name": "Tracy Teal",
-      "orcid": "0000-0002-9180-9598"
-    },
-    {
-      "name": "Dev Paudel",
-      "orcid": "0000-0002-0739-4343"
-    },
-    {
-      "name": "Paul Miller"
-    },
-    {
-      "name": "Anne Fouilloux",
-      "orcid": "0000-0002-1784-2920"
-    },
-    {
-      "name": "Chris Prener",
-      "orcid": "0000-0002-4310-9888"
-    },
-    {
-      "name": "Ethan P White",
-      "orcid": "0000-0001-6728-7745"
-    },
-    {
-      "name": "Katrin Leinweber",
-      "orcid": "0000-0001-5135-5758"
-    },
-    {
-      "name": "Michael Koontz",
-      "orcid": "0000-0002-8276-210X"
-    },
-    {
-      "name": "Whalen"
+      "name": "Kunal Marwaha",
+      "orcid": "0000-0001-9084-6971"
     }
   ],
   "license": {


### PR DESCRIPTION
updating the `.zenodo.json` with metadata about contributors since last release, in preparation for the infrastructure transition.