### PR TITLE
Fix link to workshop overview setup instructions

### DIFF
--- a/learners/setup.md
+++ b/learners/setup.md
@@ -2,6 +2,6 @@
 title: Setup
 ---
 
-Setup instructions for this workshop are available from the [Data Carpentry Geospatial Workshop Overview site](https://datacarpentry.org/geospatial-workshop/setup.html).
+Setup instructions for this workshop are available from the [Data Carpentry Geospatial Workshop Overview site](https://datacarpentry.org/geospatial-workshop/index.html#setup).
 
 


### PR DESCRIPTION
Fixes link to the setup instructions. Many thanks to the community member who reported this by email 🙌 